### PR TITLE
Add Ethereum Wingman to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ A Claude Code plugin marketplace from Trail of Bits providing skills to enhance 
 
 **[GitHub](https://github.com/trailofbits/skills)**
 
+### Ethereum Wingman
+
+An AI skill that teaches agents how to build Ethereum dApps through SpeedRun Ethereum challenges, Scaffold-ETH 2 tooling, and security best practices. Works with Claude Code, Cursor, Codex, and other AI coding agents.
+
+**[Website](https://ethwingman.com/)**
+**[GitHub](https://github.com/austintgriffith/ethereum-wingman)**
+
 ## Directories
 
 Discover other onchain agents.


### PR DESCRIPTION
Adding Ethereum Wingman — an AI agent skill for Ethereum dApp development using SpeedRun Ethereum challenges and Scaffold-ETH 2. Website: https://ethwingman.com/