### PR TITLE
Add ERC-7710 — Delegated Permissions to Standards & Protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ Standard for registering and verifying agent identity onchain. Enables agents to
 
 **[Website](https://www.8004.org/)**
 
+### ERC-7710 — Delegated Permissions
+
+Standard for scoped, revocable delegation of onchain authority. Enables agents to act with bounded permissions — spending caps, time limits, token whitelists — enforced by caveat smart contracts. Supports composable permission chains for agent-to-agent delegation.
+
+**[EIP](https://eips.ethereum.org/EIPS/eip-7710)**
+**[GitHub](https://github.com/MetaMask/delegation-framework)**
+
 ### ERC-8128 — Wallet-based Authentication
 
 Extension of RFC 9421 HTTP Message Signatures for Ethereum wallets. Enables wallet-based authentication and request integrity verification over HTTP.


### PR DESCRIPTION
## Description

Adds [ERC-7710](https://eips.ethereum.org/EIPS/eip-7710) to the **Standards & Protocols** section.

ERC-7710 defines a standard for scoped, revocable delegation of onchain authority — enabling AI agents to act with bounded permissions (spending caps, time limits, token whitelists) enforced by caveat smart contracts. It supports composable permission chains for agent-to-agent delegation.

The list currently covers agent identity (ERC-8004), payments (x402), and authentication (ERC-8128), but is missing a standard for **agent permissions/delegation**. ERC-7710 fills this gap.

The [Delegation Framework](https://github.com/MetaMask/delegation-framework) is deployed on Ethereum mainnet, Base, and 10+ other chains.