### PR TITLE
Add SIWA to Standards & Protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Extension of RFC 9421 HTTP Message Signatures for Ethereum wallets. Enables wall
 
 ### SIWA — Sign In With Agent
 
-Authentication protocol that enables servers to distinguish between AI agents and humans. Built on ERC-8004 and ERC-8128, it provides trustless identity and authentication for AI agents in two phases: sign-in via onchain identity verification, and cryptographically signed session requests.
+Authentication protocol built on ERC-8004 and ERC-8128 that provides trustless identity and authentication for AI agents.
 
 **[Website](https://siwa.id)**
 **[Docs](https://siwa.id/docs)**


### PR DESCRIPTION
## Summary
- Adds [SIWA (Sign In With Agent)](https://siwa.id) to the Standards & Protocols section
- SIWA is an authentication protocol built on ERC-8004 and ERC-8128 that provides trustless identity and authentication for AI agents

## Links
- Website: https://siwa.id
- Docs: https://siwa.id/docs
- GitHub: https://github.com/builders-garden/siwa
- npm: https://www.npmjs.com/package/@buildersgarden/siwa

🤖 Generated with [Claude Code](https://claude.com/claude-code)