### PR TITLE
enhance: expand OpenClaw section + add Clawhub skills marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ Open-source frameworks for building and running AI agents.
 
 ### OpenClaw
 
-A local‑first, OS‑level autonomous agent framework.  It connects chat apps (WhatsApp, Telegram, Discord, etc.) to an agent that can control a computer via a skills system.
+A local‑first, OS‑level autonomous agent framework. Connects chat apps (WhatsApp, Telegram, Discord, Signal, etc.) to an agent that can autonomously control a computer — run scripts, call APIs, sign transactions, and manage wallets — via a composable skills system. Supports persistent memory, scheduled heartbeats, sub-agent spawning, and native onchain integrations (ERC-8004 identity, ENS, Base, Farcaster, and more).
 
 **[Docs](https://docs.openclaw.ai/getting-started)**
+**[GitHub](https://github.com/openclaw/openclaw)**
+**[Discord](https://discord.com/invite/clawd)**
+**[Skills Marketplace](https://clawhub.com)**
 
 ### ElizaOS
 
@@ -170,8 +173,13 @@ Privacy-preserving identity verification protocol using zero-knowledge proofs. A
 
 A collection of open-source libraries, tools, and applications designed to allow agents and other utilities to transparently make web3 payments using web2 infrastructure. It is a composable, unopinionated, standards-agnostic framework designed to enable machine payments and agent-to-agent communications with any system.
 
-
 **[Docs](https://docs.faremeter.xyz/)**
+
+### Clawhub
+
+Community skills marketplace for OpenClaw agents. Installable skill packs cover onchain actions (token deployment, ENS, NFT auctions, IPFS pinning), social platforms (Farcaster, X, Moltbook, Discord), memory and scheduling, and DeFi tools — each as a self-contained SKILL.md with scripts the agent can call directly.
+
+**[Website](https://clawhub.com)**
 
 ## Directories
 


### PR DESCRIPTION
Two small improvements to the OpenClaw ecosystem coverage:

**1. Expanded OpenClaw framework entry**

The current entry is minimal (docs link only). Added GitHub repo, Discord community, and the Skills Marketplace link — same link density as other well-documented entries like ElizaOS. Also tightened the description to better communicate what makes it useful for onchain builders: wallet management, transaction signing, native Base/Farcaster/ERC-8004 integrations, and scheduled autonomy via heartbeats.

**2. Added Clawhub — OpenClaw skills marketplace**

Clawhub (https://clawhub.com) is the community hub for installable OpenClaw skill packs. Skills are self-contained modules that extend what an agent can do: token deployment via Clanker, ENS primary name setting, NFT auction bidding, IPFS pinning, Farcaster posting, QR coin auctions, ERC-8004 registration, and more. Each skill is a SKILL.md + scripts that the agent reads and executes directly.

It fits naturally under Developer Tools alongside Ethskills and Trail of Bits — it's the same category (extend your agent's capabilities) but OpenClaw-native.

Happy to adjust either entry if the descriptions feel off.