### PR TITLE
Add AFTA to Standards & Protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ Authentication protocol built on ERC-8004 and ERC-8128 that provides trustless i
 **[GitHub](https://github.com/builders-garden/siwa)**
 **[npm](https://www.npmjs.com/package/@buildersgarden/siwa)**
 
+### AFTA — Agent Fair-Trade Agreement
+
+Open standard for paid agent APIs. Sits on top of x402 (or any rail) and adds bilateral fair-trade guarantees: code-enforced no-charge paths for upstream errors, Ed25519-signed receipts the agent can verify offline, and machine-readable dispute defense for the publisher. MIT, no protocol fee, no signup.
+
+**[Website](https://tensorfeed.ai/afta)**
+**[Spec](https://github.com/RipperMercs/afta)**
+**[Cloudflare Worker template](https://github.com/RipperMercs/afta-cloudflare-worker)**
+
 ## MCP Servers
 
 Connect your agent to Ethereum blockchain data.


### PR DESCRIPTION
## What

Adds AFTA (Agent Fair-Trade Agreement) to the Standards & Protocols section, alongside x402, ERC-8004, ERC-7710, ERC-8128, and SIWA.

## Why it fits

AFTA is an open standard layered on top of x402 (or any payment rail). Where x402 defines *how to pay*, AFTA defines *what fairness guarantees both sides get* on every paid agent call:

- **Code-enforced no-charge paths** for upstream errors and policy violations. The agent gets a deterministic guarantee that it is not billed when the publisher fails.
- **Ed25519-signed receipts** the agent can verify offline. Publisher signs every charge; agent has machine-readable proof of what was billed and why.
- **Machine-readable dispute defense** for the publisher: the same receipts are the publisher'\''s evidence in a dispute.

MIT licensed, no protocol fee, no signup. Ships as a spec plus a [drop-in Cloudflare Worker template](https://github.com/RipperMercs/afta-cloudflare-worker).

Live integration: [tensorfeed.ai](https://tensorfeed.ai) issues AFTA receipts on every premium endpoint, settled in USDC on Base via x402.

Format follows the existing entries (heading, one-paragraph description, bold link list).