### PR TITLE
Add ERC-8183 (escrow) and CardZero (Base reference impl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ Standard for registering and verifying agent identity onchain. Enables agents to
 
 **[Website](https://www.8004.org/)**
 
+### ERC-8183 — Agentic Commerce (Service-Delivery Escrow)
+
+EVM-native escrow standard for agent-to-agent service delivery. Where x402 settles instantly per request, ERC-8183 holds funds in escrow across a Job lifecycle (`createJob → approve → fund → submit → complete | reject`) so a neutral Evaluator can adjudicate disputes on-chain. Stablecoin-denominated, 3-way fee splits enforced by the contract, refund-on-expiry, and writes feedback to ERC-8004 ReputationRegistry on settlement.
+
+**[EIP](https://eips.ethereum.org/EIPS/eip-8183)**
+**[Discussion](https://ethereum-magicians.org/t/erc-8183-agentic-commerce/27902)**
+
 ### ERC-7710 — Delegated Permissions
 
 Standard for scoped, revocable delegation of onchain authority. Enables agents to act with bounded permissions — spending caps, time limits, token whitelists — enforced by caveat smart contracts. Supports composable permission chains for agent-to-agent delegation.
@@ -163,6 +170,17 @@ Management platform and SDK for agent payments. Built on **x402**, **A2A**, and 
 **[Website](https://ampersend.ai)**
 **[Docs](https://docs.ampersend.io)**
 **[GitHub](https://github.com/edgeandnode/ampersend)**
+
+### CardZero
+
+Smart-contract wallet (ERC-4337) for AI agents on Base mainnet. Owner sets spending rules off-chain (per-tx limit, daily cap, whitelist, freeze) via dashboard; agent transacts USDC autonomously within them. Buyer-side **x402** support is built in. Runs the first known production deployment of **ERC-8004** (identity + reputation) and **ERC-8183** (escrow Jobs) on a public mainnet — useful as a runnable reference for either standard.
+
+**[Website](https://cardzero.ai)**
+**[Docs](https://cardzero.ai/docs)**
+**[GitHub](https://github.com/mrocker/CardZero)**
+**[npm (MCP)](https://www.npmjs.com/package/cardzero-mcp)**
+**[OpenAPI](https://github.com/mrocker/CardZero/blob/main/openapi.yaml)**
+**[llms-full.txt](https://cardzero.ai/llms-full.txt)**
 
 ### Self
 


### PR DESCRIPTION
This PR adds two onchain-agent entries:

### Standards & Protocols → add **ERC-8183 — Agentic Commerce (Service-Delivery Escrow)**

The list already includes ERC-8004, ERC-7710, ERC-8128, and x402. ERC-8183 is the natural complement: an EVM-native escrow standard for agent-to-agent **service delivery** (vs x402's per-request micropayment case). Lifecycle is `createJob → approve → fund → submit → complete | reject`. 3-way fee splits (provider/evaluator/platform) enforced by the contract, refund-on-expiry, and ERC-8183 contracts can write feedback directly into ERC-8004 ReputationRegistry on settlement — so the two standards compose natively.

Links:
- [EIP](https://eips.ethereum.org/EIPS/eip-8183)
- [Discussion thread](https://ethereum-magicians.org/t/erc-8183-agentic-commerce/27902)

### Developer Tools → add **CardZero**

Sits naturally next to Ampersend (also Base-native, also agent-payment-focused). Differences:
- ERC-4337 smart-contract wallet (rather than off-chain custody)
- Owner sets rules in a dashboard; agent uses an API key bound to a session-key on-chain
- First known production deployment of ERC-8004 + ERC-8183 → useful as a runnable reference for either standard

Links: site, docs, GitHub, npm MCP server, OpenAPI, `/llms-full.txt`.

Both entries follow the existing list style (heading + paragraph + bullet links). One PR per CONTRIBUTING.md guidance, but I batched both items in this single PR since they're closely related (ERC-8183 spec + CardZero implementation reference). Happy to split into two PRs if preferred.
