### PR TITLE
Add Block Lottos Agent API

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,14 @@ Agent wallet infrastructure and token launch platform on Base. Provides AI agent
 **[Docs](https://docs.bankr.bot)**
 **[X](https://x.com/bankrbot)**
 
+### Block Lottos Agent API
+
+Agent-readable onchain lottery and advertising API for Base and Polygon. Agents can discover live draws, read jackpot and contract status, check wallet tickets and prizes, fetch ad inventory, and prepare user-signed wallet transactions without server-side key custody.
+
+**[Website](https://blocklottos.com/games)**
+**[Agent Manifest](https://blocklottos.com/.well-known/agent.json)**
+**[OpenAPI](https://blocklottos.com/openapi.json)**
+
 ## Directories
 
 Discover other onchain agents.


### PR DESCRIPTION
Adds Block Lottos as an agent-readable onchain lottery and advertising API for Base and Polygon.\n\nVerification:\n- Website: https://blocklottos.com/games returns HTTP 200\n- Agent manifest: https://blocklottos.com/.well-known/agent.json returns HTTP 200\n- OpenAPI: https://blocklottos.com/openapi.json returns HTTP 200 and exposes OpenAPI 3.1.0 with 15 paths\n- README diff is a single Developer Tools entry\n- git diff --check passes