### PR TITLE
Add AgentsCoin MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ Research and due diligence across complex contracts, transactions, and wallets. 
 **[Article and Examples](https://x.com/andrewhong5297/status/2025973649212088721)**
 **[Herd Explorer](http://herd.eco/)**
 
+### AgentsCoin MCP Server
+
+Give your AI agent its own money — create a wallet, get AGENT from a faucet (in chat), send, and create/trade tokens on a live EVM chain. MCP server plus a one-click Claude Desktop extension. 9 tools.
+
+**[GitHub](https://github.com/axiosdevs/agentscoin-mcp)**
+**[Claude Desktop Extension](https://github.com/axiosdevs/agentscoin-claude-extension)**
+**[npm](https://www.npmjs.com/package/agentscoin-mcp)**
+**[Website](https://agents-coin.com)**
+
 ## Developer Tools
 
 Skills and tools to enhance your agent's Ethereum knowledge.


### PR DESCRIPTION
Adds **AgentsCoin** to the **MCP Servers** section (one new subsection, placed after Herd MCP Server, matching the existing subsection-per-entry format).

AgentsCoin gives an AI agent its own money on a live EVM chain: it can create a wallet, request AGENT from a faucet directly in chat, send funds, and create/trade tokens — 9 tools total. It ships as an MCP server (npm `agentscoin-mcp`, `npx agentscoin-mcp`, or remote URL `https://agents-coin.com/mcp`) plus a one-click Claude Desktop extension (`.mcpb`).

Links:
- MCP server: https://github.com/axiosdevs/agentscoin-mcp
- Claude Desktop extension: https://github.com/axiosdevs/agentscoin-claude-extension
- Site: https://agents-coin.com

It fits the MCP Servers list as an onchain EVM wallet/faucet/token MCP for agents. Exactly one entry added; no other changes.