### PR TITLE
Add AgentServices — x402-paid crypto market data MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ Research and due diligence across complex contracts, transactions, and wallets. 
 **[Article and Examples](https://x.com/andrewhong5297/status/2025973649212088721)**
 **[Herd Explorer](http://herd.eco/)**
 
+### AgentServices
+
+Production-ready MCP server with 37 tools for crypto market data, onchain analytics, and DeFi intelligence. Covers 54 services across 97 API endpoints with x402 pay-per-use payments on Base. Real-time FX/forex rates, crypto prices, technical indicators, and market intelligence.
+
+**[Website](https://agentservices.to)**
+**[GitHub](https://github.com/vbkotecha/agentservices)**
+**[MCP Server](https://agentservices.to/mcp)**
+
 ## Developer Tools
 
 Skills and tools to enhance your agent's Ethereum knowledge.


### PR DESCRIPTION
## What

Added AgentServices to the MCP Servers section — a production-ready MCP server with 37 tools for crypto market data, onchain analytics, and DeFi intelligence.

- 54 services, 97 API endpoints
- x402 pay-per-use payments on Base (USDC)
- 37 MCP tools covering crypto prices, FX/forex rates, technical indicators, market intelligence
- Streamable-http transport

The server is live at https://agentservices.to/mcp with payment-required (HTTP 402) responses on paid endpoints.

## Where

Added under MCP Servers, after existing blockchain data servers. First x402-paid entry.