### PR TITLE
Add Aeon under Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ Typically used to create tokenized agents that post on social (e.g. X), trade, o
 
 **[Website](https://www.virtuals.io/)**
 
+### Aeon
+
+Autonomous agent framework that runs entirely on GitHub Actions — enable Markdown "skills", schedule them on cron, and each run is a fresh headless coding-agent invocation. Self-healing and fleet-replicating, it ships 70+ skills and runs on six coding-agent harnesses (Claude Code, Grok, Codex, Pi, Vibe, Kimi).
+
+Onchain, Aeon deploys Uniswap v4 hooks, settles x402 payments, and operates Base + Bankr agent wallets, with MCP-native access to Base for onchain monitoring and forensics.
+
+**[GitHub](https://github.com/aeonfun/aeon)**
+
 ## Deployment Setup Guides
 
 ### Mac Mini


### PR DESCRIPTION
Adding **[Aeon](https://github.com/aeonfun/aeon)** under **Frameworks**.

Aeon is an open-source autonomous agent framework that runs entirely on GitHub Actions — no long-lived server. You enable Markdown "skills", schedule them on cron, and each run is a fresh headless coding-agent invocation. It is self-healing (a health skill detects failures and a repair skill fixes them by PR) and fleet-replicating, ships 70+ skills, and runs on six coding-agent harnesses.

Fits this list because it is an onchain AI agent framework alongside the existing Frameworks entries: it deploys Uniswap v4 hooks, settles **x402** payments, and operates Base + **Bankr** agent wallets (both already listed here), with MCP-native access to Base for onchain monitoring and forensics.

- Repo: https://github.com/aeonfun/aeon
- License: MIT · actively maintained (daily commits)

Placed at the end of Frameworks, single entry, formatting matches the surrounding lines.
